### PR TITLE
Fix deployment to GitHub pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,11 +3,13 @@ on:
     branches: [ master ]
   repository_dispatch:
     types: [ update_website ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build_website:
     runs-on: ubuntu-latest
-    name: 'Build and deploy website'
+    name: 'Build website'
     steps:
 
     # Check out repositories
@@ -46,9 +48,20 @@ jobs:
     - name: Build Python-Blosc2 docs
       run: sphinx-build -b html python-blosc2/doc _site/python-blosc2
 
-    # Deploy
     - name: Upload GitHub Pages artifact
       uses: actions/upload-pages-artifact@v1
 
+  deploy_website:
+    needs: build_website
+    if: ${{ github.event_name == "push" || github.event_name == "repository_dispatch" }}
+    runs-on: ubuntu-latest
+    name: 'Deploy website'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
     - name: Deploy to GitHub Pages
       uses: actions/deploy-pages@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
 
   deploy_website:
     needs: build_website
-    if: ${{ github.event_name == "push" || github.event_name == "repository_dispatch" }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'repository_dispatch' }}
     runs-on: ubuntu-latest
     name: 'Deploy website'
     permissions:


### PR DESCRIPTION
xref #2

Looks like the new deployment to GitHub pages is more complex than I thought. Until recently, GitHub pages was using a git branch for the built website (which doesn't make a lot of sense). Just recently they copied GitLab and added a filesystem where to copy the files to be served in GitHub pages. But seems this step is more complex than a single action and require some permissions and environment variables. Adding them here.

I also run everything in this workflow except the deployment for PRs. While the deployment won't be tested until merged, at least the building of the website will.

Assuming this is working now, this will still require changing a setting in the GitHub pages option (to not use a branch anymore). But I've got permissions now to do it.